### PR TITLE
Fix Program 5 prio and offset

### DIFF
--- a/SPOCK/long_term_scheduler.py
+++ b/SPOCK/long_term_scheduler.py
@@ -40,7 +40,7 @@ iers.IERS_A_URL = 'https://datacenter.iers.org/data/9/finals2000A.all'  # 'http:
 ssl._create_default_https_context = ssl._create_unverified_context
 
 from .make_night_plans import make_np, make_astra_schedule_file, offset_target_position
-from .upload_night_plans import upload_np_artemis, upload_np_saint_ex, upload_np_io, upload_np_gany, upload_np_euro, \
+from .upload_night_plans import upload_np, upload_np_artemis, upload_np_saint_ex, upload_np_io, upload_np_gany, upload_np_euro, \
     upload_np_calli, upload_np_tn, upload_np_ts
 
 
@@ -1517,7 +1517,7 @@ class Schedules:
                 10 ** (4 + 1 / (1 + 200 - self.target_table_spc['nb_hours_surved'][idx_on_going]))
             self.priority['priority'][idx_to_be_done] *= \
                 10 ** (1 / (1 + 200 - self.target_table_spc['nb_hours_surved'][idx_to_be_done]))
-            self.priority['priority'][idx_prog5] *= 10 * self.target_table_spc['SNR_Spec_temp'][idx_prog5] * 0
+            self.priority['priority'][idx_prog5] *= -1 #10 * self.target_table_spc['SNR_Spec_temp'][idx_prog5] * 0
             self.priority['priority'][idx_done] = -1
             
 

--- a/SPOCK/make_night_plans.py
+++ b/SPOCK/make_night_plans.py
@@ -42,10 +42,10 @@ def offset_target_position(day_start, nb_days, telescope, ra_offset, dec_offset)
         for i in range(len(scheduler_table)):
             coord = SkyCoord(
                 str(int(scheduler_table['ra (h)'][i])) + ":" + str(int(scheduler_table['ra (m)'][i])) + ":" + str(
-                    scheduler_table['ra (s)'][i])
+                    int(scheduler_table['ra (s)'][i]))
                              + " " +
-                             str(int(scheduler_table['dec (d)'][i])) + ":" + str(int(scheduler_table['dec (m)'][i])) + ":" + str(
-                    scheduler_table['dec (s)'][i])
+                             str(int(scheduler_table['dec (d)'][i])) + ":" + str(abs(int(scheduler_table['dec (m)'][i]))) + ":" + str(
+                    abs(int(scheduler_table['dec (s)'][i])))
                             , unit=(u.hourangle, u.deg))
             
             new_c = SkyCoord(ra=coord.ra.to(u.deg) + ra_offset/3600*u.deg,


### PR DESCRIPTION
Added a priority of -1 for program 5 targets, fixed the bug with the offset for negative decs, fixed the upload plans of the LT that I forgot last time.