### PR TITLE
Pin mphot dependency to 1.2.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -87,7 +87,7 @@ matplotlib==3.10.1
 matplotlib-inline==0.1.7
 mistune==3.1.3
 more-itertools==10.8.0
--e git+https://github.com/ppp-one/mphot@832639a93b65d2c113e74059e7f93a68953847e8#egg=mphot
+mphot==1.2.3
 narwhals==1.38.0
 nbclassic==1.3.1
 nbclient==0.10.2


### PR DESCRIPTION
Replace the editable VCS requirement for mphot (previously a git+https reference) with a pinned PyPI release (mphot==1.2.3) in requirements.txt to improve reproducible installs and remove the direct git dependency. Tested with a fresh installation, working fine.