### PR TITLE
Update in mphot package instalation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -87,7 +87,7 @@ matplotlib==3.10.1
 matplotlib-inline==0.1.7
 mistune==3.1.3
 more-itertools==10.8.0
-mphot==1.2.3
+mphot @ git+https://github.com/ppp-one/mphot.git@main
 narwhals==1.38.0
 nbclassic==1.3.1
 nbclient==0.10.2


### PR DESCRIPTION
Further test show me that the mphot==1.2.3 was buiilt without resources/ directory which produce errors in SPOCKapp_v2 execution. The mphot @ git+https://github.com/ppp-one/mphot.git@main installation copies all files including resources/systems/ and resources/filters/ into site-packages/mphot/ (Remember to update passwords.csv with the proper package path after installation).