### PR TITLE
Improve scheduler diagnostics

### DIFF
--- a/SPOCK/long_term_scheduler.py
+++ b/SPOCK/long_term_scheduler.py
@@ -695,7 +695,7 @@ def save_schedule(save, over_write, date_range, telescope):
             print(Fore.GREEN + 'INFO:  ' + Fore.BLACK + ' Those plans have not been saved')
 
 
-def make_plans(day, nb_days, telescope):
+def make_plans(day, nb_days, telescope, defocus_entries=None, force_autofocus=False):
     """ make plans for telescope for a certain number of day from a start day
 
     Parameters
@@ -714,7 +714,7 @@ def make_plans(day, nb_days, telescope):
     """
 
     make_np(day, nb_days, telescope)
-    make_astra_schedule_file(day, nb_days, telescope)
+    make_astra_schedule_file(day, nb_days, telescope, defocus_entries=defocus_entries, force_autofocus=force_autofocus)
 
 
 def upload_plans(day, nb_days, telescope):

--- a/SPOCK/make_night_plans.py
+++ b/SPOCK/make_night_plans.py
@@ -714,7 +714,7 @@ def make_astra_schedule_file(day, nb_days, telescope):
             elif 'ch_' in scheduler_table['target'][i] or 'Ch_' in scheduler_table['target'][i]:
                 action_values_target = {'object': name[i], 'filter': filt[i], 'ra': coords.ra.value, 'dec': coords.dec.value,
                             'exptime': int(texp[i]), 'guiding': True, 'pointing': True, 
-                            'dir': f'C:/Users/speculoos/Documents/astra/images/Chilean/{str(t_now)}'}
+                            'dir': 'C:/Users/speculoos/Documents/astra/images/Chilean'}
             else:
                 action_values_target = {'object': name[i], 'filter': filt[i], 'ra': coords.ra.value, 'dec': coords.dec.value,
                             'exptime': int(texp[i]), 'guiding': True, 'pointing': True}

--- a/SPOCK/make_night_plans.py
+++ b/SPOCK/make_night_plans.py
@@ -518,7 +518,16 @@ def get_open_close_times_saintex(day, num_filters=1):
     return full_open.iso, full_close.iso
 
 
-def make_astra_schedule_file(day, nb_days, telescope):
+def make_astra_schedule_file(day, nb_days, telescope, defocus_entries=None, force_autofocus=False):
+    """
+    defocus_entries : list of dict, optional
+        Each dict has keys 'target' (str), 'filter' (str), 'value' (int).
+        Example: [{'target': 'HD98800', 'filter': "r'", 'value': -260},
+                  {'target': 'TRAPPIST-1', 'filter': 'I+z', 'value': -100}]
+    force_autofocus : bool, optional
+        When True, behaves as if it is the 3rd of the month: skips the dome
+        rotation and inserts an autofocus block after the first target.
+    """
     t0 = Time(day)
     dt = Time('2018-01-02 00:00:00', scale='tcg') - Time('2018-01-01 00:00:00', scale='tcg')  # 1 day
 
@@ -532,10 +541,13 @@ def make_astra_schedule_file(day, nb_days, telescope):
         scheduler_table = Table.read(path_spock + '/DATABASE/' + str(telescope) + '/Archive_night_blocks' +
                                      '/night_blocks_' + str(telescope) + '_' + str(t_now) + '.txt', format='ascii')
         is_third_of_month = int(t_now.split('-')[2]) == 3  # True when the plan date is the 3rd of the month
+        do_autofocus = is_third_of_month or force_autofocus  # forced manually or on the 3rd
         if (telescope == 'Io') or telescope == ('Europa') or (telescope == 'Ganymede') or (telescope == 'Callisto'):
-            if not is_third_of_month:
+            if not do_autofocus:
                 scheduler_table = dome_rotation(telescope=telescope, day_of_night=t_now)  # Intentional dome rotation to
                 # avoid technical pb on Callisto with dome
+            elif force_autofocus and not is_third_of_month:
+                print(Fore.GREEN + 'INFO: ' + Fore.BLACK + f' Manual autofocus requested: skipping dome rotation for {telescope} on {t_now}')
         name = scheduler_table['target']
         config = scheduler_table['configuration']
         filt = []
@@ -718,17 +730,34 @@ def make_astra_schedule_file(day, nb_days, telescope):
             else:
                 action_values_target = {'object': name[i], 'filter': filt[i], 'ra': coords.ra.value, 'dec': coords.dec.value,
                             'exptime': int(texp[i]), 'guiding': True, 'pointing': True}
+            # Inject focus_shift if defocus is requested for this target/filter
+            if defocus_entries:
+                for _entry in defocus_entries:
+                    if name[i] == _entry['target'] and filt[i] == _entry['filter']:
+                        action_values_target['focus_shift'] = int(_entry['value'])
+                        print(Fore.GREEN + 'INFO: ' + Fore.BLACK +
+                              f" Defocus focus_shift={_entry['value']} applied to {name[i]} ({filt[i]})")
+                        break
             target_row = pd.Series({"device_name": "camera_"+str(telescope).replace("-",""),
                              "action_type": "object",	"action_value": action_values_target,
                              "start_time": (Time(scheduler_table["start time (UTC)"][i] ) + 1*u.min).iso,
                                     "end_time": scheduler_table["end time (UTC)"][i]})
             df = pd.concat([df, pd.DataFrame([target_row])], ignore_index=True)
 
-            # On the 3rd of each month, insert an autofocus action after the first target
-            if is_third_of_month and i == 0 and len(scheduler_table) > 1:
-                autofocus_start = Time(scheduler_table["end time (UTC)"][0]) + 1 * u.min
-                autofocus_end   = Time(scheduler_table["end time (UTC)"][1])
+            # On the 3rd of each month (or when manually forced), insert an autofocus action after the first target
+            if do_autofocus and i == 0:
                 autofocus_filter = "zYJ" if telescope == "Callisto" else "I+z"
+                if len(scheduler_table) > 1:
+                    # Multi-target night: insert autofocus between target[0] and target[1]
+                    autofocus_start = Time(scheduler_table["end time (UTC)"][0]) + 1 * u.min
+                    autofocus_end   = Time(scheduler_table["end time (UTC)"][1])
+                else:
+                    # Single-target night: insert autofocus in the middle of the target block
+                    t_start = Time(scheduler_table["start time (UTC)"][0])
+                    t_end   = Time(scheduler_table["end time (UTC)"][0])
+                    midpoint = Time((t_start.jd + t_end.jd) / 2, format='jd')
+                    autofocus_start = midpoint
+                    autofocus_end   = midpoint + 10 * u.min
                 autofocus_row = pd.Series({
                     "device_name": "camera_" + str(telescope).replace("-", ""),
                     "action_type": "autofocus",
@@ -743,8 +772,9 @@ def make_astra_schedule_file(day, nb_days, telescope):
                     "start_time": autofocus_start.iso,
                     "end_time":   autofocus_end.iso})
                 df = pd.concat([df, pd.DataFrame([autofocus_row])], ignore_index=True)
+                reason = "forced manually" if (force_autofocus and not is_third_of_month) else "3rd of month"
                 print(Fore.GREEN + 'INFO: ' + Fore.BLACK +
-                      f' Autofocus block added for {telescope} on {t_now} (3rd of month)')
+                      f' Autofocus block added for {telescope} on {t_now} ({reason})')
 
         # Flats MORNING
         my_custom_order_morning = my_custom_order_evening[::-1]# temporaty fix for Callisto 

--- a/SPOCK/make_night_plans_manuel.py
+++ b/SPOCK/make_night_plans_manuel.py
@@ -831,7 +831,7 @@ def make_astra_schedule_file(day, nb_days, telescope):
             elif 'ch_' in scheduler_table['target'][i] or 'Ch_' in scheduler_table['target'][i]:
                 action_values_target = {'object': name[i], 'filter': filt[i], 'ra': coords.ra.value, 'dec': coords.dec.value,
                             'exptime': int(texp[i]), 'guiding': True, 'pointing': True, 
-                            'dir': f'C:/Users/speculoos/Documents/astra/images/Chilean/{str(t_now)}'}
+                            'dir': 'C:/Users/speculoos/Documents/astra/images/Chilean'}
             else:
                 action_values_target = {'object': name[i], 'filter': filt[i], 'ra': coords.ra.value, 'dec': coords.dec.value,
                             'exptime': int(texp[i]), 'guiding': True, 'pointing': True}

--- a/SPOCK/short_term_scheduler.py
+++ b/SPOCK/short_term_scheduler.py
@@ -1271,7 +1271,7 @@ class Schedules:
         else:
             #filters list
             filt_ = target_list['Filter_spc'][i].values[0]
-            if (filt_ == 'z\'') or (filt_ == 'r\'') or (filt_ == 'i\'') or (filt_ == 'g\''):
+            if (filt_ == 'z\'') or (filt_ == 'r\'') or (filt_ == 'i\'') or (filt_ == 'g\'') or (filt_ == 'u\''):
                 filt_ = filt_.replace('\'', '')
             if filt_ == 'zcut':
                 filt_ = 'z'
@@ -1358,11 +1358,11 @@ class Schedules:
                 if target_list['Teff'][i].values[0] is not None and target_list['distance'][i].values[0] is not None:
                     try:
                         andor = mphot.get_precision(props_telescope_ANDOR, props_sky, #source_id=target_list["Gaia_ID"][i].values[0],
-                                                    Teff=target_list["Teff"][i].values[0],distance=target_list["distance"][i].values[0])
+                                                    Teff=float(target_list["Teff"][i].values[0]),distance=float(target_list["distance"][i].values[0]))
                     except FileNotFoundError:
                         print(Fore.GREEN + 'INFO: ' + Fore.BLACK + ' Re-running the grid for mphot, can take 30s')
                         andor = mphot.get_precision(props_telescope_ANDOR, props_sky, #source_id=target_list["Gaia_ID"][i].values[0],
-                                                    Teff=target_list["Teff"][i].values[0], distance=target_list["distance"][i].values[0], override_grid=True)
+                                                    Teff=float(target_list["Teff"][i].values[0]), distance=float(target_list["distance"][i].values[0]), override_grid=True)
                 else:
                     try:
                         andor = mphot.get_precision_gaia(props_telescope_ANDOR, props_sky, source_id=target_list["Gaia_ID"][i].values[0], 

--- a/SPOCK/short_term_scheduler.py
+++ b/SPOCK/short_term_scheduler.py
@@ -17,6 +17,7 @@ from docx.shared import *
 from datetime import date, timedelta, datetime
 from eScheduler.spe_schedule import SPECULOOSScheduler, Schedule, ObservingBlock, Transitioner
 import gspread
+import hashlib
 import matplotlib.pyplot as plt
 import mphot
 # path_mphot = mphot.__file__.replace('__init__.py', '')
@@ -514,7 +515,14 @@ class Schedules:
             constraints_special_target = [AltitudeConstraint(min=self.altitude_constraint * u.deg),
                                         MoonSeparationConstraint(min=self.moon_constraint * u.deg),
                                         TimeConstraint(start, end)]
-            idx_to_insert_target = int(np.where((self.target_table_spc['Sp_ID'] == input_name))[0])
+            
+            # Find the target index
+            matches = np.where((self.target_table_spc['Sp_ID'] == input_name))[0]
+            if len(matches) == 0:
+                print(Fore.RED + 'ERROR: ' + Fore.BLACK + f'Target "{input_name}" not found in target table.')
+                print(Fore.CYAN + 'Available targets: ' + Fore.BLACK + ', '.join(self.target_table_spc['Sp_ID'].astype(str)))
+                raise ValueError(f'Target "{input_name}" not found')
+            idx_to_insert_target = int(matches[0])
 
             ## WARNING with Next and Nearest
             rise_target = self.observatory.target_rise_time(self.start_of_observation, self.targets[idx_to_insert_target],  which='nearest', 
@@ -1150,11 +1158,13 @@ class Schedules:
             return self.scheduled_table
         else:
             try:
-                self.scheduled_table = read_night_block(telescope=self.telescope,
+                # Use sync-check version to prevent concurrent edit conflicts
+                self.scheduled_table = read_night_block_with_sync_check(telescope=self.telescope,
                                                         day=self.day_of_night.tt.datetime.strftime("%Y-%m-%d"))
                 return self.scheduled_table
             except TypeError:
-                self.scheduled_table = read_night_block(telescope=self.telescope,
+                # Fallback to sync-check version if needed
+                self.scheduled_table = read_night_block_with_sync_check(telescope=self.telescope,
                                                         day=self.day_of_night.tt.datetime.strftime("%Y-%m-%d"))
                 return self.scheduled_table
 
@@ -1482,6 +1492,114 @@ def upload_plans(day, nb_days, telescope):
  #                     path_database_home_masterfile])
 
 
+def read_night_block_with_sync_check(telescope, day):
+    """
+    Read night block with server sync check - prevents data loss from concurrent edits.
+    
+    Before scheduling, this function:
+    1. Fetches the latest plan from the server
+    2. Compares with local version
+    3. Warns if they differ (colleague may have uploaded changes)
+    4. Updates local file if server version is newer
+    5. Returns the synchronized schedule
+    
+    Parameters:
+    -----------
+    telescope : str
+        Telescope name (e.g., 'Artemis', 'Saint-Ex')
+    day : str or datetime
+        Observation date
+        
+    Returns:
+    --------
+    scheduler_table : pd.DataFrame or astropy.Table
+        The synchronized night plan
+    """
+    day_fmt = Time(day, scale='utc', out_subfmt='date').tt.datetime.strftime("%Y-%m-%d")
+    path_local = path_spock + '/DATABASE/' + telescope + '/Archive_night_blocks/night_blocks_' + telescope + '_' + \
+                 day_fmt + '.txt'
+    
+    # Step 1: Try to fetch from server
+    nightb_url = "https://www.mrao.cam.ac.uk/SPECULOOS/Observations/" + telescope + '/schedule/Archive_night_blocks/night_blocks_' + \
+                 telescope + '_' + day_fmt + '.txt'
+    
+    try:
+        nightb_server = requests.get(nightb_url, auth=(user_portal, pwd_portal), timeout=10)
+        server_available = (nightb_server.status_code == 200)
+        server_content = nightb_server.content if server_available else None
+    except Exception as e:
+        print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK + f'Could not fetch plan from server - {e}')
+        server_available = False
+        server_content = None
+    
+    # Step 2: Check if local plan exists
+    local_exists = os.path.exists(path_local)
+    
+    if server_available and server_content:
+        # Both local and server available - check for conflicts
+        if local_exists:
+            # Compare local vs server
+            try:
+                with open(path_local, 'rb') as f:
+                    local_content = f.read()
+                
+                # Simple MD5 hash comparison to detect changes
+                import hashlib
+                local_hash = hashlib.md5(local_content).hexdigest()
+                server_hash = hashlib.md5(server_content).hexdigest()
+                
+                if local_hash != server_hash:
+                    print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK + 
+                          f'⚠️  CONFLICT DETECTED on {day_fmt}!')
+                    print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK + 
+                          'Your local plan differs from the server plan.')
+                    print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK + 
+                          'This may indicate a colleague has updated the schedule.')
+                    print(Fore.CYAN + 'INFO: ' + Fore.BLACK + 
+                          'Using SERVER version (most recent) to prevent data loss.')
+                    print(Fore.CYAN + 'INFO: ' + Fore.BLACK + 
+                          'If you need your local changes, check "See night plans" tab to review.')
+                else:
+                    print(Fore.GREEN + 'INFO: ' + Fore.BLACK + 
+                          f'Local plan is synchronized with server ({day_fmt})')
+            except Exception as e:
+                print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK + f'Could not compare plans - {e}')
+        
+        # Update local file with server version (ensures sync)
+        try:
+            os.makedirs(os.path.dirname(path_local), exist_ok=True)
+            with open(path_local, 'wb') as f:
+                f.write(server_content)
+            print(Fore.GREEN + 'INFO: ' + Fore.BLACK + 'Local plan updated from server')
+        except Exception as e:
+            print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK + f'Could not update local plan - {e}')
+        
+        # Load and return the table
+        try:
+            scheduler_table = pd.read_csv(path_local, delimiter=' ', skipinitialspace=True)
+            return scheduler_table
+        except Exception as e:
+            print(Fore.RED + 'ERROR: ' + Fore.BLACK + f'Could not parse night plan - {e}')
+            raise
+    
+    elif local_exists:
+        # Only local available
+        print(Fore.GREEN + 'INFO: ' + Fore.BLACK + 
+              'Using local plan (server unavailable)')
+        try:
+            scheduler_table = Table.read(path_local, format='ascii')
+            return scheduler_table
+        except Exception as e:
+            print(Fore.RED + 'ERROR: ' + Fore.BLACK + f'Could not read local plan - {e}')
+            raise
+    
+    else:
+        # Neither local nor server
+        print(Fore.RED + 'ERROR: ' + Fore.BLACK + f'No plans available for {telescope} on {day_fmt}')
+        print(Fore.YELLOW + 'INFO: ' + Fore.BLACK + 'Checked: Local DATABASE and server')
+        raise FileNotFoundError(f'No night plan found for {telescope} on {day_fmt}')
+
+
 def read_night_block(telescope, day):
     day_fmt = Time(day, scale='utc', out_subfmt='date').tt.datetime.strftime("%Y-%m-%d")
     path_local = path_spock + '/DATABASE/' + telescope + '/Archive_night_blocks/night_blocks_' + telescope + '_' + \
@@ -1504,6 +1622,7 @@ def read_night_block(telescope, day):
             open(path_local, 'wb').write(nightb.content)
             scheduler_table = pd.read_csv(path_local, delimiter=' ', skipinitialspace=True,)
     return scheduler_table
+
 
 
 def date_range_in_days(date_range):

--- a/SPOCK/short_term_scheduler.py
+++ b/SPOCK/short_term_scheduler.py
@@ -1449,9 +1449,9 @@ def save_schedule(save, over_write, day, telescope):
         print(Fore.GREEN + 'INFO:  ' + Fore.BLACK + ' Those plans have not been saved')
 
 
-def make_plans(day, nb_days, telescope):
+def make_plans(day, nb_days, telescope, defocus_entries=None, force_autofocus=False):
     make_np(day, nb_days, telescope)
-    make_astra_schedule_file(day, nb_days, telescope)
+    make_astra_schedule_file(day, nb_days, telescope, defocus_entries=defocus_entries, force_autofocus=force_autofocus)
 
 
 def upload_plans(day, nb_days, telescope):

--- a/SPOCK/short_term_scheduler.py
+++ b/SPOCK/short_term_scheduler.py
@@ -641,19 +641,39 @@ class Schedules:
             W_err_transit = df['W_err'][i]
             target_transit = EclipsingSystem(primary_eclipse_time=epoch, orbital_period=period, duration=duration,
                                              name=df['Sp_ID'][i])
-            print(Fore.GREEN + Fore.GREEN + Fore.GREEN + 'INFO: ' + Fore.BLACK + ' ' + Fore.BLACK +
-                  Fore.BLACK + str(df['Sp_ID'][i]) + ' next transit: ',
-                  Time(target_transit.next_primary_eclipse_time(self.day_of_night, n_eclipses=1)).iso)
-            timing_to_obs_jd = Time(target_transit.next_primary_eclipse_time(self.day_of_night, n_eclipses=1)).jd
-            n_transits = 1
+            # Check up to 3 upcoming transits — the first may fall before dark (daytime),
+            # while the one that actually belongs to this night may cross midnight.
+            _n_check = 3
+            _night_end = self.day_of_night + 1
+            _all_mid = Time(target_transit.next_primary_eclipse_time(self.day_of_night, n_eclipses=_n_check)).jd
+            print(Fore.GREEN + 'INFO: ' + Fore.BLACK + str(df['Sp_ID'][i]) + ' next transit: ',
+                  Time(_all_mid[0], format='jd').iso)
             try:
-                ing_egr = target_transit.next_primary_ingress_egress_time(self.day_of_night, n_eclipses=n_transits)
+                _all_ing_egr = target_transit.next_primary_ingress_egress_time(self.day_of_night, n_eclipses=_n_check)
             except ValueError:
                 print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK + ' No transit of ', df['Sp_ID'][i],
                       ' on the period chosen')
+                _all_ing_egr = None
 
-            observable = is_event_observable(constraints_follow_up, self.observatory, self.targets_follow_up,
-                                             times_ingress_egress=ing_egr)
+            # Walk through upcoming transits to find the first one observable this night
+            observable = np.array([[False]])
+            ing_egr = _all_ing_egr[0:1] if _all_ing_egr is not None else None
+            timing_to_obs_jd = np.array([_all_mid[0]])
+            if _all_ing_egr is not None:
+                for _t_idx in range(_n_check):
+                    _mid_t = Time(_all_mid[_t_idx], format='jd')
+                    if _mid_t > _night_end:
+                        break
+                    _single_ie = _all_ing_egr[_t_idx:_t_idx + 1]
+                    _obs = is_event_observable(constraints_follow_up, self.observatory, self.targets_follow_up,
+                                               times_ingress_egress=_single_ie)
+                    if np.any(_obs):
+                        observable = _obs
+                        ing_egr = _single_ie
+                        timing_to_obs_jd = np.array([_all_mid[_t_idx]])
+                        print(Fore.GREEN + 'INFO: ' + Fore.BLACK + str(df['Sp_ID'][i]) +
+                              ' observable transit mid-time: ', _mid_t.iso)
+                        break
             if np.any(observable):
                 err_T0_neg = T0_err_transit  # timing_to_obs_jd[0] -
                 # (np.round((timing_to_obs_jd[0] - epoch.jd) / period.value, 1) *(period.value -
@@ -774,19 +794,37 @@ class Schedules:
                 W_err_transit = df['W_err'][i]
                 target_transit = EclipsingSystem(primary_eclipse_time=epoch, orbital_period=period,
                                                  duration=duration, name=df['Sp_ID'][i])
-                print(Fore.GREEN + Fore.GREEN + Fore.GREEN + 'INFO: ' + Fore.BLACK + ' ' +
-                      Fore.BLACK + Fore.BLACK + str(df['Sp_ID'][i]) + ' next transit: ',
-                      Time(target_transit.next_primary_eclipse_time(self.day_of_night, n_eclipses=1)).iso)
-                timing_to_obs_jd = Time(target_transit.next_primary_eclipse_time(self.day_of_night, n_eclipses=1)).jd
-                n_transits = 1
+                _n_check = 3
+                _night_end = self.day_of_night + 1
+                _all_mid = Time(target_transit.next_primary_eclipse_time(self.day_of_night, n_eclipses=_n_check)).jd
+                print(Fore.GREEN + 'INFO: ' + Fore.BLACK + str(df['Sp_ID'][i]) + ' next transit: ',
+                      Time(_all_mid[0], format='jd').iso)
                 try:
-                    ing_egr = target_transit.next_primary_ingress_egress_time(self.day_of_night, n_eclipses=n_transits)
+                    _all_ing_egr = target_transit.next_primary_ingress_egress_time(
+                        self.day_of_night, n_eclipses=_n_check)
                 except ValueError:
                     print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK + ' No transit of ',
                           df['Sp_ID'][i], ' on the period chosen')
+                    _all_ing_egr = None
 
-                observable = is_event_observable(constraints, self.observatory,
-                                                 self.targets_follow_up, times_ingress_egress=ing_egr)
+                observable = np.array([[False]])
+                ing_egr = _all_ing_egr[0:1] if _all_ing_egr is not None else None
+                timing_to_obs_jd = np.array([_all_mid[0]])
+                if _all_ing_egr is not None:
+                    for _t_idx in range(_n_check):
+                        _mid_t = Time(_all_mid[_t_idx], format='jd')
+                        if _mid_t > _night_end:
+                            break
+                        _single_ie = _all_ing_egr[_t_idx:_t_idx + 1]
+                        _obs = is_event_observable(constraints, self.observatory,
+                                                   self.targets_follow_up, times_ingress_egress=_single_ie)
+                        if np.any(_obs):
+                            observable = _obs
+                            ing_egr = _single_ie
+                            timing_to_obs_jd = np.array([_all_mid[_t_idx]])
+                            print(Fore.GREEN + 'INFO: ' + Fore.BLACK + str(df['Sp_ID'][i]) +
+                                  ' observable transit mid-time: ', _mid_t.iso)
+                            break
                 if np.any(observable):
                     err_T0_neg = timing_to_obs_jd[0] - (np.round((timing_to_obs_jd[0] - epoch.jd) / period.value, 1) *
                                                         (period.value - P_err_transit) + (epoch.jd - T0_err_transit))

--- a/SPOCK/upload_night_plans.py
+++ b/SPOCK/upload_night_plans.py
@@ -4,6 +4,9 @@ import os
 from astropy.time import Time
 from SPOCK import pwd_HUB, pwd_appcs, pwd_SNO_Reduc1, path_spock
 import traceback
+from colorama import Fore
+import threading
+import socket
 
 import paramiko
 
@@ -61,34 +64,258 @@ def upload_folder(sftp, local_folder, remote_folder):
             sftp.put(local_file, remote_file)
 
 
+def test_connections():
+    """
+    Test SSH/SFTP connections to all servers. Use this to diagnose connectivity issues.
+    Tests in phases: Ping → SSH → SFTP
+    Returns a dict with connection status for each server.
+    """
+    import socket
+    
+    results = {
+        'Cambridge': {'ping': False, 'ssh': False, 'sftp': False, 'client': None},
+        'SSO_hub': {'ping': False, 'ssh': False, 'sftp': False, 'client': None},
+        'SNO_hub': {'ping': False, 'ssh': False, 'sftp': False, 'client': None},
+    }
+    
+    servers = {
+        'Cambridge': ('appcs.ra.phy.cam.ac.uk', pwd_appcs),
+        'SSO_hub': ('172.16.4.169', pwd_HUB),
+        'SNO_hub': ('10.16.83.11', pwd_SNO_Reduc1),
+    }
+    
+    print(Fore.CYAN + '=' * 70 + Fore.BLACK)
+    print(Fore.CYAN + 'SPOCK Connection Diagnostic (3-Phase Test)' + Fore.BLACK)
+    print(Fore.CYAN + '=' * 70 + Fore.BLACK)
+    
+    # ========== PHASE 1: PING ==========
+    print(Fore.CYAN + '\n[PHASE 1] Testing Ping (Port 22 reachability)...' + Fore.BLACK)
+    for server_name, (host, pwd) in servers.items():
+        print(f'  Testing {server_name} ({host})...')
+        try:
+            sock = socket.create_connection((host, 22), timeout=5)
+            sock.close()
+            print(Fore.GREEN + f'    ✓ Ping: SUCCESS' + Fore.BLACK)
+            results[server_name]['ping'] = True
+        except socket.timeout:
+            print(Fore.RED + f'    ✗ Ping: TIMEOUT (5s) - Network unreachable or blocked' + Fore.BLACK)
+            results[server_name]['ping'] = False
+        except socket.error as e:
+            print(Fore.RED + f'    ✗ Ping: FAILED - {e}' + Fore.BLACK)
+            results[server_name]['ping'] = False
+    
+    # ========== PHASE 2: SSH ==========
+    print(Fore.CYAN + '\n[PHASE 2] Testing SSH Authentication...' + Fore.BLACK)
+    for server_name, (host, pwd) in servers.items():
+        if not results[server_name]['ping']:
+            print(f'  {server_name}: Skipped (ping failed)')
+            continue
+        
+        print(f'  Testing {server_name} ({host})...')
+        test_client = paramiko.SSHClient()
+        test_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        test_client.load_system_host_keys()
+        try:
+            test_client.connect(host, username="speculoos", password=pwd, timeout=10, banner_timeout=10)
+            print(Fore.GREEN + f'    ✓ SSH: SUCCESS' + Fore.BLACK)
+            results[server_name]['ssh'] = True
+            results[server_name]['client'] = test_client  # Keep for SFTP phase
+        except Exception as e:
+            print(Fore.RED + f'    ✗ SSH: FAILED - {e}' + Fore.BLACK)
+            results[server_name]['ssh'] = False
+            test_client.close()
+    
+    # ========== PHASE 3: SFTP ==========
+    print(Fore.CYAN + '\n[PHASE 3] Testing SFTP Session (with 5s timeout)...' + Fore.BLACK)
+    for server_name in servers.keys():
+        if not results[server_name]['ssh']:
+            print(f'  {server_name}: Skipped (SSH failed)')
+            continue
+        
+        print(f'  Testing {server_name} SFTP...')
+        test_client = results[server_name]['client']
+        
+        # Use threading to enforce timeout on open_sftp
+        sftp_result = {'sftp': None, 'error': None}
+        
+        def open_sftp_with_timeout():
+            try:
+                # Set socket timeout on transport before opening SFTP
+                transport = test_client.get_transport()
+                if transport and transport.sock:
+                    transport.sock.settimeout(5)
+                
+                print(f'    Opening SFTP channel (5s timeout)...')
+                sftp_result['sftp'] = test_client.open_sftp()
+            except Exception as e:
+                sftp_result['error'] = e
+        
+        sftp_thread = threading.Thread(target=open_sftp_with_timeout, daemon=True)
+        sftp_thread.start()
+        sftp_thread.join(timeout=7)  # Give it 7 seconds (5s + buffer)
+        
+        if sftp_thread.is_alive():
+            print(Fore.RED + f'    ✗ SFTP: TIMEOUT (5s) - open_sftp() hanging, possible network issue' + Fore.BLACK)
+            results[server_name]['sftp'] = False
+            try:
+                test_client.close()
+            except:
+                pass
+            continue
+        
+        if sftp_result['error']:
+            print(Fore.RED + f'    ✗ SFTP: FAILED - {sftp_result["error"]}' + Fore.BLACK)
+            results[server_name]['sftp'] = False
+            try:
+                test_client.close()
+            except:
+                pass
+            continue
+        
+        if not sftp_result['sftp']:
+            print(Fore.RED + f'    ✗ SFTP: FAILED - Could not open SFTP session' + Fore.BLACK)
+            results[server_name]['sftp'] = False
+            try:
+                test_client.close()
+            except:
+                pass
+            continue
+        
+        # SFTP opened successfully, test with listdir
+        try:
+            test_sftp = sftp_result['sftp']
+            test_sftp.get_channel().settimeout(5)
+            
+            print(f'    Testing SFTP listdir command...')
+            test_sftp.listdir_attr('.')
+            
+            print(Fore.GREEN + f'    ✓ SFTP: SUCCESS' + Fore.BLACK)
+            results[server_name]['sftp'] = True
+            test_sftp.close()
+        except socket.timeout:
+            print(Fore.RED + f'    ✗ SFTP: TIMEOUT during listdir (5s)' + Fore.BLACK)
+            results[server_name]['sftp'] = False
+        except Exception as e:
+            print(Fore.RED + f'    ✗ SFTP: FAILED during listdir - {e}' + Fore.BLACK)
+            results[server_name]['sftp'] = False
+        finally:
+            try:
+                test_client.close()
+            except:
+                pass
+    
+    # ========== SUMMARY ==========
+    print(f'\n' + Fore.CYAN + '=' * 70 + Fore.BLACK)
+    print(Fore.CYAN + 'Summary' + Fore.BLACK)
+    print(Fore.CYAN + '=' * 70 + Fore.BLACK)
+    
+    for server_name in servers.keys():
+        status = results[server_name]
+        ping_ok = '✓' if status['ping'] else '✗'
+        ssh_ok = '✓' if status['ssh'] else '✗'
+        sftp_ok = '✓' if status['sftp'] else '✗'
+        print(f'{server_name:12} | Ping: {ping_ok} | SSH: {ssh_ok} | SFTP: {sftp_ok}')
+    
+    all_ok = all(results[s]['ping'] and results[s]['ssh'] and results[s]['sftp'] for s in servers.keys())
+    
+    print(Fore.CYAN + '=' * 70 + Fore.BLACK)
+    if all_ok:
+        print(Fore.GREEN + '✓✓✓ All connections successful! Ready to upload.' + Fore.BLACK)
+    else:
+        print(Fore.RED + '✗✗✗ Some connections failed. Troubleshooting tips:' + Fore.BLACK)
+        print(Fore.YELLOW + '  • Ping fails → Check VPN, firewall, or server IP address' + Fore.BLACK)
+        print(Fore.YELLOW + '  • SSH fails → Check credentials in passwords.csv' + Fore.BLACK)
+        print(Fore.YELLOW + '  • SFTP fails → Check network latency or remote permissions' + Fore.BLACK)
+    
+    return results
+
+
 def upload_np(t_now, nb_day, telescope):
     t0 = Time(t_now)
     dt = Time("2018-01-02 00:00:00", scale="tcg") - Time(
         "2018-01-01 00:00:00", scale="tcg"
     )  # 1 day
 
-    # Connect to the remote server
+    # Initialize SFTP clients
+    sftp_cambridge = None
+    sftp_SSO_hub = None
+    sftp_SNO_hub = None
+    cambridge_available = False
+    
     try:
-        ssh_client_cambridge.connect(
-            "appcs.ra.phy.cam.ac.uk", username="speculoos", password=pwd_appcs
-        )
+        # ========== CAMBRIDGE (optional - non-critical) ==========
+        try:
+            print(Fore.GREEN + 'INFO: ' + Fore.BLACK + ' Connecting to Cambridge archive (non-critical)...')
+            ssh_client_cambridge.connect(
+                "appcs.ra.phy.cam.ac.uk", username="speculoos", password=pwd_appcs, timeout=10
+            )
+            print(Fore.GREEN + 'INFO: ' + Fore.BLACK + ' Connected to Cambridge SSH!')
+            
+            # Open SFTP with timeout using threading
+            sftp_result = {'sftp': None, 'error': None}
+            
+            def open_cambridge_sftp():
+                try:
+                    print(Fore.GREEN + 'INFO: ' + Fore.BLACK + ' Opening Cambridge SFTP channel (10s timeout)...')
+                    transport = ssh_client_cambridge.get_transport()
+                    if transport and transport.sock:
+                        transport.sock.settimeout(10)
+                    sftp_result['sftp'] = ssh_client_cambridge.open_sftp()
+                except Exception as e:
+                    sftp_result['error'] = e
+            
+            sftp_thread = threading.Thread(target=open_cambridge_sftp, daemon=True)
+            sftp_thread.start()
+            sftp_thread.join(timeout=12)  # Give 12 seconds (10s + buffer)
+            
+            if sftp_thread.is_alive():
+                print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK + ' Cambridge SFTP timeout (10s) - skipping archive upload')
+                cambridge_available = False
+            elif sftp_result['error']:
+                print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK + f' Cambridge SFTP failed - {sftp_result["error"]}')
+                cambridge_available = False
+            elif sftp_result['sftp']:
+                sftp_cambridge = sftp_result['sftp']
+                sftp_cambridge.get_channel().settimeout(10)
+                print(Fore.GREEN + 'INFO: ' + Fore.BLACK + ' SFTP Cambridge ready')
+                cambridge_available = True
+            else:
+                print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK + ' Cambridge SFTP could not open')
+                cambridge_available = False
+                
+        except Exception as e:
+            print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK + f' Cambridge archive connection failed (non-critical) - {e}')
+            print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK + ' Continuing with SSO/SNO hub uploads...')
+            cambridge_available = False
+        
+        # ========== HUB SERVERS (critical) ==========
+        print(Fore.GREEN + 'INFO: ' + Fore.BLACK + ' Connecting to SSO hub (172.16.4.169)...')
         ssh_client_SSO_hub.connect(
-            "172.16.4.169", username="speculoos", password=pwd_HUB
+            "172.16.4.169", username="speculoos", password=pwd_HUB, timeout=30
         )
-        ssh_client_SNO_hub.connect(
-            "10.16.83.11", username="speculoos", password=pwd_SNO_Reduc1
-        )
-        print("Connected to the servers!")
-        # Open SFTP sessions
-        sftp_cambridge = ssh_client_cambridge.open_sftp()
+        print(Fore.GREEN + 'INFO: ' + Fore.BLACK + ' Connected to SSO hub!')
         sftp_SSO_hub = ssh_client_SSO_hub.open_sftp()
+        sftp_SSO_hub.get_channel().settimeout(30)
+        print(Fore.GREEN + 'INFO: ' + Fore.BLACK + ' SFTP SSO hub ready')
+        
+        print(Fore.GREEN + 'INFO: ' + Fore.BLACK + ' Connecting to SNO hub (10.16.83.11)...')
+        ssh_client_SNO_hub.connect(
+            "10.16.83.11", username="speculoos", password=pwd_SNO_Reduc1, timeout=30
+        )
+        print(Fore.GREEN + 'INFO: ' + Fore.BLACK + ' Connected to SNO hub!')
         sftp_SNO_hub = ssh_client_SNO_hub.open_sftp()
+        sftp_SNO_hub.get_channel().settimeout(30)
+        print(Fore.GREEN + 'INFO: ' + Fore.BLACK + ' SFTP SNO hub ready')
+        
+        if cambridge_available:
+            print(Fore.GREEN + 'INFO: ' + Fore.BLACK + ' All servers connected!')
+        else:
+            print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK + ' Hub servers ready (Cambridge unavailable)')
 
         for nb_day in range(0, nb_day):
             t_now = Time(t0 + nb_day * dt, scale="utc", out_subfmt="date").iso
 
-            # Cambridge server
-            # Plans by date
+            # Cambridge server paths
             path_database_plans = os.path.join(
                 "../../appct/data/SPECULOOSPipeline/Observations/",
                 telescope,
@@ -160,51 +387,28 @@ def upload_np(t_now, nb_day, telescope):
                 or (telescope == "Callisto")
             ):
 
-                # Upload the file
-                upload_folder(sftp_cambridge, path_plans, path_database_plans)
-                print(
-                    "----->",
-                    t_now,
-                    "Plans uploaded on the Cambridge server for",
-                    telescope,
-                )
-
-                sftp_cambridge.put(path_night_blocks, path_database_nightb)
-                print(
-                    "----->",
-                    t_now,
-                    "Night plans uploaded on the Cambridge server for",
-                    telescope,
-                )
-
-                sftp_cambridge.put(path_local_zip_file, path_database_zip_file)
-                print(
-                    "----->",
-                    t_now,
-                    "Zip Plans_by_dates folder uploaded on the Cambridge server for",
-                    telescope,
-                )
-
-                print(f"Uploading from local: {path_local_zip_file} to remote: {path_hub_zip_files}")
+                # ========== CAMBRIDGE UPLOADS (optional) ==========
+                if cambridge_available:
+                    try:
+                        print(Fore.GREEN + 'INFO: ' + Fore.BLACK + f' Uploading to Cambridge for {telescope}...')
+                        upload_folder(sftp_cambridge, path_plans, path_database_plans)
+                        sftp_cambridge.put(path_night_blocks, path_database_nightb)
+                        sftp_cambridge.put(path_local_zip_file, path_database_zip_file)
+                        sftp_cambridge.put(path_local_astra_jsonl, path_database_astra)
+                        print(Fore.GREEN + 'INFO: ' + Fore.BLACK + f' All files uploaded to Cambridge for {telescope}')
+                    except Exception as e:
+                        print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK + f' Cambridge upload failed (continuing): {e}')
+                else:
+                    print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK + ' Skipping Cambridge upload (not available)')
+                
+                # ========== HUB UPLOADS (critical) ==========
+                print(Fore.GREEN + 'INFO: ' + Fore.BLACK + f' Uploading to HUB servers for {telescope}...')
                 try:
                     sftp_SSO_hub.put(path_local_zip_file, path_hub_zip_files)
-                    print(
-                        "----->",
-                        t_now,
-                        "Zip Plans_by_dates folder uploaded on the HUB for",
-                        telescope,
-                    )
+                    print(Fore.GREEN + '----->' + Fore.BLACK + f' {t_now} Zip Plans uploaded to SSO hub for {telescope}')
                 except OSError as e:
-                    print(f"SFTP upload failed: {e}")
-                # if (telescope == "Callisto") or (telescope == "Ganymede"):
-                    
-                sftp_cambridge.put(path_local_astra_jsonl, path_database_astra)
-                print(
-                "----->",
-                t_now,
-                "Astra folder updated on the Cambridge server for",
-                telescope,
-                )
+                    print(Fore.RED + 'ERROR: ' + Fore.BLACK + f' SSO hub upload failed: {e}')
+                
                 path_hub_astra = os.path.normpath(
                     os.path.join(
                         "/home/speculoos/Plans_scheduler/",
@@ -213,13 +417,11 @@ def upload_np(t_now, nb_day, telescope):
                         jsonl_file,
                     )
                 )
-                sftp_SSO_hub.put(path_local_astra_jsonl, path_hub_astra)
-                print(
-                    "----->",
-                    t_now,
-                    "Astra folder updated on the HUB for",
-                    telescope,
-                )
+                try:
+                    sftp_SSO_hub.put(path_local_astra_jsonl, path_hub_astra)
+                    print(Fore.GREEN + '----->' + Fore.BLACK + f' {t_now} Astra plans uploaded to SSO hub for {telescope}')
+                except OSError as e:
+                    print(Fore.RED + 'ERROR: ' + Fore.BLACK + f' SSO hub astra upload failed: {e}')
                 # else:
                 #     sftp_cambridge.put(path_local_astra_csv, path_database_astra)
                 #     print(
@@ -245,64 +447,60 @@ def upload_np(t_now, nb_day, telescope):
                     # )
 
             if (telescope == "Artemis") or (telescope == "Saint-Ex"):
-                # Upload the file
-                upload_folder(sftp_cambridge, path_plans, path_database_plans)
-                print(
-                    "----->",
-                    t_now,
-                    "Plans uploaded on the Cambridge server for",
-                    telescope,
-                )
-
-                sftp_cambridge.put(path_night_blocks, path_database_nightb)
-                print(
-                    "----->",
-                    t_now,
-                    "Night plans uploaded on the Cambridge server for",
-                    telescope,
-                )
-
-                sftp_cambridge.put(path_local_zip_file, path_database_zip_file)
-                print(
-                    "----->",
-                    t_now,
-                    "Zip Plans_by_dates folder uploaded on the Cambridge server for",
-                    telescope,
-                )
-
-                if telescope == "Saint-Ex":
-                    sftp_cambridge.put(path_local_astra_csv, path_database_astra)
-                    print(
-                        "----->",
-                        t_now,
-                        "Astra folder updated on the Cambridge server for",
-                        telescope,
-                    )
-
+                # ========== CAMBRIDGE UPLOADS (optional) ==========
+                if cambridge_available:
+                    try:
+                        print(Fore.GREEN + 'INFO: ' + Fore.BLACK + f' Uploading to Cambridge for {telescope}...')
+                        upload_folder(sftp_cambridge, path_plans, path_database_plans)
+                        sftp_cambridge.put(path_night_blocks, path_database_nightb)
+                        sftp_cambridge.put(path_local_zip_file, path_database_zip_file)
+                        if telescope == "Saint-Ex":
+                            sftp_cambridge.put(path_local_astra_csv, path_database_astra)
+                        print(Fore.GREEN + 'INFO: ' + Fore.BLACK + f' All files uploaded to Cambridge for {telescope}')
+                    except Exception as e:
+                        print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK + f' Cambridge upload failed (continuing): {e}')
+                else:
+                    print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK + ' Skipping Cambridge upload (not available)')
+                
+                # ========== HUB UPLOADS (critical) ==========
                 if telescope == "Artemis":
-                    sftp_SNO_hub.put(path_local_zip_file, path_hub_SNO_zip_files)
-                    print(
-                        "----->",
-                        t_now,
-                        "Zip Plans_by_dates folder uploaded on the HUB for",
-                        telescope,
-                    )
+                    try:
+                        sftp_SNO_hub.put(path_local_zip_file, path_hub_SNO_zip_files)
+                        print(Fore.GREEN + '----->' + Fore.BLACK + f' {t_now} Zip Plans uploaded to SNO hub for {telescope}')
+                    except OSError as e:
+                        print(Fore.RED + 'ERROR: ' + Fore.BLACK + f' SNO hub upload failed: {e}')
 
+    except paramiko.ssh_exception.SSHException as e:
+        print(Fore.RED + f'ERROR: SSH connection failed - {e}' + Fore.BLACK)
+        print(Fore.RED + 'ERROR: ' + Fore.BLACK + ' Hub servers are critical. Check your VPN connection.' + Fore.BLACK)
+        traceback.print_exc()
+    except TimeoutError as e:
+        print(Fore.RED + f'ERROR: Connection timed out - {e}' + Fore.BLACK)
+        print(Fore.RED + 'ERROR: ' + Fore.BLACK + ' Network unreachable. Verify VPN connection.' + Fore.BLACK)
+        traceback.print_exc()
+    except OSError as e:
+        print(Fore.RED + f'ERROR: Connection or file error - {e}' + Fore.BLACK)
+        print(Fore.RED + 'ERROR: ' + Fore.BLACK + ' Check network and file paths.' + Fore.BLACK)
+        traceback.print_exc()
     except Exception as e:
-        print(f"Failed to connect: {e}")
+        print(Fore.RED + f'ERROR: Unexpected error - {e}' + Fore.BLACK)
         traceback.print_exc()
 
     finally:
+        print(Fore.GREEN + 'INFO: ' + Fore.BLACK + ' Closing connections...')
         try:
-            sftp_cambridge.close()
+            if sftp_cambridge:
+                sftp_cambridge.close()
         except:
             pass
         try:
-            sftp_SSO_hub.close()
+            if sftp_SSO_hub:
+                sftp_SSO_hub.close()
         except:
             pass
         try:
-            sftp_SNO_hub.close()
+            if sftp_SNO_hub:
+                sftp_SNO_hub.close()
         except:
             pass
         try:

--- a/SPOCK/upload_night_plans.py
+++ b/SPOCK/upload_night_plans.py
@@ -76,7 +76,7 @@ def upload_np(t_now, nb_day, telescope):
             "172.16.4.169", username="speculoos", password=pwd_HUB
         )
         ssh_client_SNO_hub.connect(
-            "172.16.3.11", username="speculoos", password=pwd_SNO_Reduc1
+            "10.16.83.11", username="speculoos", password=pwd_SNO_Reduc1
         )
         print("Connected to the servers!")
         # Open SFTP sessions

--- a/SPOCKapp_v2.ipynb
+++ b/SPOCKapp_v2.ipynb
@@ -6,7 +6,37 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<script>\n",
+       "  function code_toggle() {\n",
+       "    if (code_shown){\n",
+       "      $('div.input').hide('500');\n",
+       "      $('#toggleButton').val('Show Code')\n",
+       "    } else {\n",
+       "      $('div.input').show('500');\n",
+       "      $('#toggleButton').val('Hide Code')\n",
+       "    }\n",
+       "    code_shown = !code_shown\n",
+       "  }\n",
+       "\n",
+       "  $( document ).ready(function(){\n",
+       "    code_shown=false;\n",
+       "    $('div.input').hide()\n",
+       "  });\n",
+       "</script>\n",
+       "<form action=\"javascript:code_toggle()\"><input type=\"submit\" id=\"toggleButton\" value=\"Show Code\"></form>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "\n",
     "%%HTML\n",
@@ -41,11 +71,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[32mINFO: \u001b[30m Please add password.csv file in: /Users/ed268546/Documents/Codes/SPOCK_v2/SPOCK/credentials\n",
+      "\u001b[32mINFO: \u001b[30m Please add password.csv file in: /Users/sebazf/Documents/GitHub/SPOCK_v2/SPOCK/credentials\n",
       "\u001b[32mINFO: \u001b[30m OK Password file exists\n",
       "\u001b[32mINFO: \u001b[30mLatest target list already updated.\n",
-      "\u001b[32mINFO: \u001b[30mTarget list already in good format\n",
-      "Warning: the archive is unstable and we are working to resolve this issue. In case of questions, please contact the Gaia helpdesk: https://www.cosmos.esa.int/web/gaia/gaia-helpdesk\n"
+      "\u001b[32mINFO: \u001b[30mTarget list already in good format\n"
      ]
     }
    ],
@@ -108,23 +137,35 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "scrolled": false
+    "scrolled": true
    },
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cbcdbd57af304764a496826c1dad1512",
+       "model_id": "b8f5001ac2f34778b118286e722740af",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "Tab(children=(Box(children=(Accordion(children=(HBox(children=(Combobox(value='', description='Site:', ensure_…"
+       "Tab(children=(Accordion(children=(HBox(children=(Combobox(value='', description='Site:', ensure_option=True, o…"
       ]
      },
      "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "Jupyter.notebook.execute_cells([9])"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "data": {
@@ -190,7 +231,7 @@
     "\n",
     "run_widget_mangos = widgets.Button(\n",
     "    value=False,\n",
-    "    description=emoji.emojize('Click to predict :mango:'),\n",
+    "    description=emoji.emojize('predict :mango:'),\n",
     "    disabled=False,\n",
     "    button_style='', # 'success', 'info', 'warning', 'danger' or ''\n",
     "    tooltip='Description',\n",
@@ -223,7 +264,7 @@
     "gotoall_widget = widgets.Button(\n",
     "    value=False,\n",
     "    description='Go to all together',\n",
-    "    layout=Layout(width='auto', height='30px'),\n",
+    "    layout=Layout(width='20%', height='30px'),\n",
     "    disabled=False,\n",
     "    button_style='', # 'success', 'info', 'warning', 'danger' or ''\n",
     "    style= {'button_color':'lightsteelblue'},\n",
@@ -243,7 +284,7 @@
     "short_term_option_widget = widgets.Combobox(\n",
     "    # value='John',\n",
     "    placeholder='Choose option',\n",
-    "    options=['Follow-up','Special target with known start/end time (mandatory for Saint-Ex)',\\\n",
+    "    options=['Follow-up','Special target with known start/end time',\\\n",
     "             'Special target (observe the most we can)','MANGOS','Dome rotation','Monitoring'],\n",
     "    description='What kind? :',\n",
     "    ensure_option=True,\n",
@@ -253,24 +294,15 @@
     "    description='Day ',\n",
     "    disabled=False)\n",
     "\n",
-    "\n",
-    "short_start_time_widget = widgets.Text(description='Start time (no need for Saint-Ex)',\n",
-    "                                       placeholder=datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),\n",
-    "                                        layout=widgets.Layout(width='500px'),\n",
-    "                                        style={'description_width': 'initial'})\n",
-    "short_end_time_widget = widgets.Text(description='End time  (no need for Saint-Ex)',\n",
-    "                                    placeholder=(datetime.datetime.now() \n",
-    "                                                 + datetime.timedelta(hours=2)).strftime('%Y-%m-%d %H:%M:%S'),\n",
-    "                                    layout=widgets.Layout(width='500px'),\n",
-    "                                        style={'description_width': 'initial'})\n",
-    "\n",
+    "short_start_time_widget = widgets.Text(description='Start time',placeholder='2020-01-16 23:00:00')\n",
+    "short_end_time_widget = widgets.Text(description='End time',placeholder='2020-01-17 03:00:00')\n",
     "\n",
     "start_time_widget =widgets.DatePicker(\n",
-    "    description='Start Time (no need for Saint-Ex)',\n",
+    "    description='Start Time',\n",
     "    disabled=False)\n",
     "\n",
     "end_time_widget =widgets.DatePicker(\n",
-    "    description='End Time (no need for Saint-Ex)',\n",
+    "    description='End Time',\n",
     "    disabled=False)\n",
     "\n",
     "#input_file_special_widget = widgets.Text(description='File',placeholder='input_short_term.csv')\n",
@@ -290,17 +322,6 @@
     "    options=list(pd.read_csv(target_list_from_stargate_path,delimiter=',')['Sp_ID']), \n",
     "    description='Target name:',\n",
     "    ensure_option=True,\n",
-    "    style = style,\n",
-    "    disabled=False)\n",
-    "\n",
-    "target_special_Saint_Ex_widget = widgets.Combobox(\n",
-    "    # value='John',\n",
-    "    placeholder='Trappist-1x',\n",
-    "    options=list(schedules_st.target_table_Saint_Ex['Sp_ID']), \n",
-    "    description='Saint-Ex special:',\n",
-    "    ensure_option=True,\n",
-    "    style = style,\n",
-    "    layout=widgets.Layout(background_color='lightyellow'),\n",
     "    disabled=False)\n",
     "\n",
     "target_special_widget = widgets.Combobox(\n",
@@ -309,7 +330,6 @@
     "    options=list(schedules_st.target_table_spc['Sp_ID']), \n",
     "    description='Target special:',\n",
     "    ensure_option=True,\n",
-    "        style = style,\n",
     "    disabled=False)\n",
     "\n",
     "target_follow_up_widget = widgets.Combobox(\n",
@@ -318,7 +338,6 @@
     "    options=list(schedules_st.target_table_spc_follow_up['Sp_ID']), \n",
     "    description='Target follow-up:',\n",
     "    ensure_option=True,\n",
-    "    style = style,\n",
     "    disabled=False)\n",
     "\n",
     "target_follow_up_mangos = widgets.Combobox(\n",
@@ -327,7 +346,6 @@
     "    options=list(schedules_mangos.target_table_spc_follow_up['Sp_ID']), \n",
     "    description='MANGOs follow-up:',\n",
     "    ensure_option=True,\n",
-    "    style = style,\n",
     "    disabled=False)\n",
     "\n",
     "plot_option_widget = widgets.Combobox(\n",
@@ -384,63 +402,17 @@
     "long_term_tab.set_title(2, 'Run long term')\n",
     "\n",
     "# ----------------------------------------------------------- #\n",
-    "highlight_box_special_target = widgets.Box(\n",
-    "    [target_special_widget],\n",
-    "    layout=widgets.Layout(\n",
-    "        border='3px solid red',\n",
-    "        padding='2px',\n",
-    "        background_color='lightyellow'\n",
-    "    )\n",
-    ")\n",
     "\n",
-    "highlight_box_follow_up = widgets.Box(\n",
-    "    [target_follow_up_widget],\n",
-    "    layout=widgets.Layout(\n",
-    "        border='3px solid blue',\n",
-    "        padding='2px',\n",
-    "        background_color='yellow'\n",
-    "    )\n",
-    ")\n",
-    "\n",
-    "highlight_box_mangos = widgets.Box(\n",
-    "    [target_follow_up_mangos],\n",
-    "    layout=widgets.Layout(\n",
-    "        border='3px solid orange',\n",
-    "        padding='2px',\n",
-    "        background_color='yellow'\n",
-    "    )\n",
-    ")\n",
-    "\n",
-    "highlight_box_Saint_Ex = widgets.Box(\n",
-    "    [target_special_Saint_Ex_widget],\n",
-    "    layout=widgets.Layout(\n",
-    "        border='3px solid turquoise',\n",
-    "        padding='2px',\n",
-    "        background_color='yellow'\n",
-    "    )\n",
-    ")\n",
-    "\n",
-    "short_term_tab = widgets.Accordion(children=[\n",
-    "    widgets.HBox([observatory_widget, telescope_widget, operator_widget]),\n",
-    "\n",
-    "    widgets.VBox([\n",
-    "        widgets.HBox([short_term_option_widget, short_day_widget]),\n",
-    "        widgets.HBox([short_start_time_widget, short_end_time_widget]),\n",
-    "        widgets.VBox([\n",
-    "            widgets.HBox([highlight_box_special_target, \n",
-    "                          widgets.Box(layout=widgets.Layout(width='15px')), highlight_box_follow_up],\n",
-    "                        layout=widgets.Layout(margin='0 0 10px 0')),\n",
-    "            widgets.HBox([highlight_box_mangos, \n",
-    "                          widgets.Box(layout=widgets.Layout(width='15px')), highlight_box_Saint_Ex],)\n",
-    "        ])\n",
-    "    ]),\n",
-    "\n",
-    "    run_widget\n",
-    "])\n",
-    "\n",
+    "short_term_tab = widgets.Accordion(children=[widgets.HBox([observatory_widget,telescope_widget,operator_widget]),\\\n",
+    "                                        widgets.VBox([widgets.HBox([short_term_option_widget,short_day_widget]),\\\n",
+    "                                        widgets.HBox([short_start_time_widget,short_end_time_widget]),\n",
+    "                                             widgets.HBox([target_special_widget,target_follow_up_widget,\n",
+    "                                                          target_follow_up_mangos])]),\n",
+    "                                             run_widget])\n",
     "short_term_tab.set_title(0, 'Observatory')\n",
     "short_term_tab.set_title(1, 'Options')\n",
     "short_term_tab.set_title(2, 'Run short term')\n",
+    "\n",
     "# ----------------------------------------------------------- #\n",
     "\n",
     "plot_tab = widgets.Accordion(children=[plot_option_widget,run_widget])\n",
@@ -449,33 +421,23 @@
     "\n",
     "# ----------------------------------------------------------- #\n",
     "\n",
-    "make_upload_tab = widgets.Accordion(\n",
-    "    children=[\n",
-    "        widgets.HBox([observatory_widget, telescope_widget]),\n",
-    "        widgets.HBox([start_date_widget, end_date_widget]),\n",
-    "        widgets.HBox([\n",
-    "            gotosave_widget,\n",
-    "            gotomake_widget,\n",
-    "            gotoupload_widget,\n",
-    "            gotoall_widget\n",
-    "        ])\n",
-    "    ]\n",
-    ")\n",
-    "\n",
-    "# Set the titles of each accordion tab\n",
-    "make_upload_tab.set_title(0, 'Observatory')\n",
-    "make_upload_tab.set_title(1, 'Date Info')\n",
-    "make_upload_tab.set_title(2, 'Go to Plan Maker & Upload')\n",
+    "make_upload_tab = widgets.Accordion(children=[widgets.HBox([observatory_widget,telescope_widget]),\\\n",
+    "                                          widgets.HBox([start_date_widget,end_date_widget]),\\\n",
+    "                                          widgets.HBox([gotosave_widget,gotomake_widget,gotoupload_widget,\\\n",
+    "                                                       gotoall_widget])])\n",
+    "make_upload_tab.set_title(0, 'Site info')\n",
+    "make_upload_tab.set_title(1, 'Date info')\n",
+    "make_upload_tab.set_title(2, 'Go to plan maker and upload')\n",
     "\n",
     "# ----------------------------------------------------------- #\n",
     "\n",
     "check_np_tab = widgets.Accordion(children=[check_np_widget])\n",
-    "check_np_tab.set_title(0, 'See night plan for a given date')\n",
+    "make_upload_tab.set_title(0, 'Click')\n",
     "\n",
     "# ----------------------------------------------------------- #\n",
     "\n",
     "info_target_tab = widgets.Accordion(children=[info_target_widget])\n",
-    "info_target_tab.set_title(0, 'Informations on targets')\n",
+    "make_upload_tab.set_title(0, 'Click')\n",
     "\n",
     "# ----------------------------------------------------------- #\n",
     "\n",
@@ -502,8 +464,7 @@
     "duration_text =  widgets.FloatText(\n",
     "    value=0.02511108,\n",
     "    description='Duration (days):',\n",
-    "    disabled=False,\n",
-    "    style={'description_width': 'initial'}\n",
+    "    disabled=False\n",
     ")\n",
     "name_widget = widgets.Text(description='Target name',placeholder='TOI-XXX')\n",
     "prediction_date_widget =widgets.DatePicker(\n",
@@ -548,112 +509,31 @@
     "\n",
     "manual_prediction_widget.on_click(run_manual_predict)\n",
     "\n",
-    "tabs = [\n",
-    "    widgets.Box([long_term_tab], layout=widgets.Layout(background_color='#f2f2f2', padding='10px')),\n",
-    "    widgets.Box([short_term_tab], layout=widgets.Layout(background_color='#e6f7ff', padding='10px')),\n",
-    "    widgets.Box([plot_tab], layout=widgets.Layout(background_color='#fff2e6', padding='10px')),\n",
-    "    widgets.Box([make_upload_tab], layout=widgets.Layout(background_color='#ffe6f2', padding='10px')),\n",
-    "    widgets.Box([check_np_tab], layout=widgets.Layout(background_color='#e6ffe6', padding='10px')),\n",
-    "    widgets.Box([info_target_tab], layout=widgets.Layout(background_color='#f9f9b0', padding='10px')),\n",
-    "    widgets.Box([predict_tab], layout=widgets.Layout(background_color='#f2e6ff', padding='10px')),\n",
-    "    widgets.Box([mango_tab], layout=widgets.Layout(background_color='#fff0b3', padding='10px'))\n",
-    "]\n",
-    "\n",
-    "tab_nest = widgets.Tab(children=tabs, layout=widgets.Layout(width='100%'))\n",
-    "\n",
-    "\n",
-    "titles = [\n",
-    "    'Long term',\n",
-    "    'Short term',\n",
-    "    'Plots',\n",
-    "    'Make & Upload',\n",
-    "    'See night plans',\n",
-    "    'Info on a target',\n",
-    "    'Predictions WG6',\n",
-    "    emoji.emojize('Predictions :mango:')\n",
-    "]\n",
-    "\n",
-    "for i, title in enumerate(titles):\n",
-    "    tab_nest.set_title(i, title)\n",
-    "\n",
+    "tab_nest = widgets.Tab()\n",
+    "tab_nest.children = [long_term_tab, short_term_tab,plot_tab,make_upload_tab,check_np_tab,info_target_tab, predict_tab, mango_tab]\n",
+    "tab_nest.set_title(0, 'Long term scheduler ')\n",
+    "tab_nest.set_title(1, 'Short term scheduler')\n",
+    "tab_nest.set_title(2, 'Plots')\n",
+    "tab_nest.set_title(3, 'Make & Upload only')\n",
+    "tab_nest.set_title(4, 'See night plans')\n",
+    "tab_nest.set_title(5, 'Info on a target')\n",
+    "tab_nest.set_title(6, 'Predictions')\n",
+    "tab_nest.set_title(7, emoji.emojize('Predictions :mango:'))\n",
     "tab_nest"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 16,
    "metadata": {
-    "code_folding": []
+    "code_folding": [],
+    "scrolled": true
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[33mWARNING: \u001b[30mObservation starts the day after the night start, adding a day\n",
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div><i>Table length=1</i>\n",
-       "<table id=\"table5206252128\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>target</th><th>start time (UTC)</th><th>end time (UTC)</th><th>duration (minutes)</th><th>ra (h)</th><th>ra (m)</th><th>ra (s)</th><th>dec (d)</th><th>dec (m)</th><th>dec (s)</th><th>configuration</th></tr></thead>\n",
-       "<thead><tr><th>str8</th><th>str23</th><th>str23</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>object</th></tr></thead>\n",
-       "<tr><td>TOI-7309</td><td>2026-04-26 06:19:09.923</td><td>2026-04-26 09:21:49.923</td><td>182.66666666666663</td><td>15.0</td><td>43.0</td><td>59.279999999998694</td><td>58.0</td><td>9.0</td><td>18.589999999989573</td><td>{&apos;filt&apos;: &apos;I+z&apos;, &apos;texp&apos;: &apos;110&apos;}</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<Table length=1>\n",
-       " target      start time (UTC)    ...         configuration         \n",
-       "  str8            str23          ...             object            \n",
-       "-------- ----------------------- ... ------------------------------\n",
-       "TOI-7309 2026-04-26 06:19:09.923 ... {'filt': 'I+z', 'texp': '110'}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32mINFO: \u001b[30m Local path exists and is:  /Archive_night_blocks/night_blocks_Saint-Ex_2026-04-25.txt\n",
-      "\u001b[32mINFO: \u001b[30m Local path exists and is:  /Archive_night_blocks/night_blocks_Saint-Ex_2026-04-25.txt\n",
-      "\u001b[32mINFO: \u001b[30m situation 6\n",
-      "\u001b[32mINFO: \u001b[30m no transition block\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div><i>Table length=3</i>\n",
-       "<table id=\"table5170767456\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>target</th><th>start time (UTC)</th><th>end time (UTC)</th><th>duration (minutes)</th><th>ra (h)</th><th>ra (m)</th><th>ra (s)</th><th>dec (d)</th><th>dec (m)</th><th>dec (s)</th><th>configuration</th></tr></thead>\n",
-       "<thead><tr><th>str13</th><th>str23</th><th>str23</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>object</th></tr></thead>\n",
-       "<tr><td>Sp1438+6408</td><td>2026-04-26 02:53:29.940</td><td>2026-04-26 06:19:09.923</td><td>205.6663833333332</td><td>14.0</td><td>38.0</td><td>9.129600000008224</td><td>64.0</td><td>8.0</td><td>36.30119999999806</td><td>{&apos;filt&apos;: &apos;I+z&apos;, &apos;texp&apos;: &apos;113&apos;}</td></tr>\n",
-       "<tr><td>TOI-7309</td><td>2026-04-26 06:19:09.923</td><td>2026-04-26 09:21:49.923</td><td>182.66666666666663</td><td>15.0</td><td>43.0</td><td>59.279999999998694</td><td>58.0</td><td>9.0</td><td>18.589999999989573</td><td>{&apos;filt&apos;: &apos;I+z&apos;, &apos;texp&apos;: &apos;110&apos;}</td></tr>\n",
-       "<tr><td>Sp1438+6408_2</td><td>2026-04-26 09:21:49.923</td><td>2026-04-26 12:25:29.940</td><td>183.66695000000007</td><td>14.0</td><td>38.0</td><td>9.129600000008224</td><td>64.0</td><td>8.0</td><td>36.30119999999806</td><td>{&apos;filt&apos;: &apos;I+z&apos;, &apos;texp&apos;: &apos;113&apos;}</td></tr>\n",
-       "</table></div>"
-      ],
-      "text/plain": [
-       "<Table length=3>\n",
-       "    target        start time (UTC)    ...         configuration         \n",
-       "    str13              str23          ...             object            \n",
-       "------------- ----------------------- ... ------------------------------\n",
-       "  Sp1438+6408 2026-04-26 02:53:29.940 ... {'filt': 'I+z', 'texp': '113'}\n",
-       "     TOI-7309 2026-04-26 06:19:09.923 ... {'filt': 'I+z', 'texp': '110'}\n",
-       "Sp1438+6408_2 2026-04-26 09:21:49.923 ... {'filt': 'I+z', 'texp': '113'}"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
      "data": {
       "application/javascript": [
-       "Jupyter.notebook.execute_cells([13])"
+       "Jupyter.notebook.execute_cells([18])"
       ],
       "text/plain": [
        "<IPython.core.display.Javascript object>"
@@ -684,7 +564,7 @@
     "        schedule.telescope = schedule.observatory_name\n",
     "    if schedule.observatory_name == 'Saint-Ex':\n",
     "        schedule.telescope = 'Saint-Ex'\n",
-    "        schedule.make_schedule(Altitude_constraint = 27, Moon_constraint = 25.5, Airmass_constraint=2.4)\n",
+    "        schedule.make_schedule(Altitude_constraint = 28, Moon_constraint = 30)\n",
     "        display(schedule.target_table_spc[schedule.idx_first_target])\n",
     "        display(schedule.target_table_spc[schedule.idx_second_target])\n",
     "        display(Javascript('Jupyter.notebook.execute_cells([13])'))\n",
@@ -737,17 +617,13 @@
     "            schedule.transit_follow_up()\n",
     "\n",
     "            \n",
-    "    if short_term_option_widget.value == 'Special target with known start/end time (mandatory for Saint-Ex)':\n",
+    "    if short_term_option_widget.value == 'Special target with known start/end time':\n",
+    "        start_date = [Time(short_start_time_widget.value).iso]\n",
+    "        end_date = [Time(short_end_time_widget.value).iso]\n",
+    "        schedule.start_end_range = Time([start_date,end_date])\n",
     "        schedule.observatory_name = observatory_widget.value\n",
-    "        if schedule.telescope == \"Saint-Ex\":\n",
-    "            input_name = target_special_Saint_Ex_widget.value\n",
-    "            schedule.special_target_with_start_end(input_name=input_name, use_Saint_Ex_spreadsheet=True)\n",
-    "        else:\n",
-    "            start_date = [Time(short_start_time_widget.value).iso]\n",
-    "            end_date = [Time(short_end_time_widget.value).iso]\n",
-    "            schedule.start_end_range = Time([start_date,end_date])\n",
-    "            input_name = target_special_widget.value\n",
-    "            schedule.special_target_with_start_end(input_name=input_name)\n",
+    "        input_name = target_special_widget.value\n",
+    "        schedule.special_target_with_start_end(input_name=input_name)\n",
     "        \n",
     "    if short_term_option_widget.value == 'Special target (observe the most we can)':\n",
     "        input_name = target_special_widget.value\n",
@@ -1011,13 +887,76 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "jupyter": {
      "source_hidden": true
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8bbbdd6cb883484596aa2c1ff3d7a126",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HBox(children=(Button(description='Make ACP plans', icon='check', layout=Layout(height='40px', …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "Jupyter.notebook.execute_cells([10])"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "Jupyter.notebook.execute_cells([10])"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "Jupyter.notebook.execute_cells([10])"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "Jupyter.notebook.execute_cells([10])"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# CELL 9 -- BUTTON -- Make plans\n",
     "makeplans_widget = widgets.Button(\n",
@@ -1025,7 +964,7 @@
     "    description='Make ACP plans',\n",
     "    layout=Layout(width='20%', height='40px'),\n",
     "    disabled=False,\n",
-    "    button_style='', # 'success', 'info', 'warning', 'danger' or ''\n",
+    "    button_style='',\n",
     "    style= {'button_color':'palegreen'},\n",
     "    tooltip='Make',\n",
     "    icon='check'\n",
@@ -1033,20 +972,81 @@
     "def run_make(b): \n",
     "    display(Javascript('Jupyter.notebook.execute_cells([10])'))\n",
     "\n",
-    "display(makeplans_widget)\n",
+    "# --- Defocus widgets ---\n",
+    "defocus_checkbox_widget = widgets.Checkbox(\n",
+    "    value=False,\n",
+    "    description='Apply defocus',\n",
+    "    disabled=False,\n",
+    "    indent=False,\n",
+    "    layout=Layout(width='150px')\n",
+    ")\n",
+    "defocus_entries_widget = widgets.Textarea(\n",
+    "    value='',\n",
+    "    placeholder=\"One entry per line: TargetName,filter,focus_shift\\ne.g.:\\nHD98800,r',-260\\nTRAPPIST-1,I+z,-100\",\n",
+    "    description='Defocus:',\n",
+    "    disabled=False,\n",
+    "    layout=Layout(width='500px', height='90px')\n",
+    ")\n",
+    "\n",
+    "# --- Manual autofocus widget ---\n",
+    "force_autofocus_widget = widgets.Checkbox(\n",
+    "    value=False,\n",
+    "    description='Force autofocus (replaces dome rotation)',\n",
+    "    disabled=False,\n",
+    "    indent=False,\n",
+    "    layout=Layout(width='350px')\n",
+    ")\n",
+    "\n",
+    "defocus_box = widgets.HBox([defocus_checkbox_widget, defocus_entries_widget])\n",
+    "\n",
+    "display(widgets.VBox([\n",
+    "    widgets.HBox([makeplans_widget]),\n",
+    "    defocus_box,\n",
+    "    force_autofocus_widget\n",
+    "]))\n",
     "\n",
     "makeplans_widget.on_click(run_make)\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {
     "jupyter": {
      "source_hidden": true
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mINFO: \u001b[30m Manual autofocus forced: dome rotation will be replaced\n",
+      "\u001b[32mINFO: \u001b[30m Path exists and is:  /Users/sebazf/Documents/GitHub/SPOCK_v2/DATABASE/Ganymede/Archive_night_blocks/night_blocks_Ganymede_2026-08-09.txt\n",
+      "\u001b[33mWARNING: \u001b[30m not possible at that time because of altitude constraint, adding 20 degrees altitude\n",
+      "\n",
+      "\u001b[32mINFO: \u001b[30m Manual autofocus requested: skipping dome rotation for Ganymede on 2026-08-09\n",
+      "\n",
+      "\u001b[32mINFO: \u001b[30mTarget HD98800 has been scheduled on the 2026-08-09 on Ganymede\n",
+      "\u001b[32mINFO: \u001b[30mTarget Sp1713-3952 has been scheduled on the 2026-08-09 on Ganymede\n",
+      "\u001b[32mINFO: \u001b[30mTarget TOI-7867.11 has been scheduled on the 2026-08-09 on Ganymede\n",
+      "\u001b[32mINFO: \u001b[30mTarget Sp2350+0806 has been scheduled on the 2026-08-09 on Ganymede\n",
+      "\u001b[32mINFO: \u001b[30m Autofocus block added for Ganymede on 2026-08-09 (forced manually)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "Jupyter.notebook.execute_cells([11])"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# CELL 10 -- Make plans\n",
     "start_date = Time(datetime.datetime.strptime(str(start_date_widget.value), '%Y-%m-%d')+datetime.timedelta(hours=15)).iso\n",
@@ -1056,37 +1056,55 @@
     "schedule.load_parameters(date_range=[start_date,end_date])\n",
     "schedule.date_range = Time([start_date,end_date])\n",
     "\n",
+    "# Parse defocus entries from textarea (format: TargetName,filter,focus_shift per line)\n",
+    "def _parse_defocus_entries(text):\n",
+    "    entries = []\n",
+    "    for line in text.strip().split('\\n'):\n",
+    "        line = line.strip()\n",
+    "        if not line:\n",
+    "            continue\n",
+    "        parts = line.split(',')\n",
+    "        if len(parts) == 3:\n",
+    "            try:\n",
+    "                entries.append({'target': parts[0].strip(), 'filter': parts[1].strip(), 'value': int(parts[2].strip())})\n",
+    "            except ValueError:\n",
+    "                print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK + f' Could not parse defocus entry: {line}')\n",
+    "    return entries if entries else None\n",
+    "\n",
+    "_defocus_entries = _parse_defocus_entries(defocus_entries_widget.value) if defocus_checkbox_widget.value else None\n",
+    "_force_autofocus = force_autofocus_widget.value\n",
+    "if _force_autofocus:\n",
+    "    print(Fore.GREEN + 'INFO: ' + Fore.BLACK + ' Manual autofocus forced: dome rotation will be replaced')\n",
+    "if _defocus_entries:\n",
+    "    print(Fore.GREEN + 'INFO: ' + Fore.BLACK + f' Defocus active for {len(_defocus_entries)} target(s): {_defocus_entries}')\n",
+    "\n",
     "if tab_nest.selected_index == 0:\n",
     "    schedule.telescope = telescope_widget.value\n",
     "    if schedule.observatory.name == 'SNO':\n",
     "        SPOCKLT.make_plans(day=schedule.date_range[0], nb_days=schedule.date_range_in_days, \n",
-    "                           telescope=schedule.telescope)\n",
-    "\n",
+    "                           telescope=schedule.telescope, defocus_entries=_defocus_entries, force_autofocus=_force_autofocus)\n",
     "    if schedule.observatory.name == 'Saint-Ex':\n",
     "        schedule.telescope = 'Saint-Ex'\n",
     "        SPOCKLT.make_plans(day=schedule.date_range[0], nb_days=schedule.date_range_in_days, \n",
-    "                           telescope=schedule.telescope)\n",
-    "\n",
+    "                           telescope=schedule.telescope, defocus_entries=_defocus_entries, force_autofocus=_force_autofocus)\n",
     "    if schedule.observatory.name == 'SSO':\n",
     "        SPOCKLT.make_plans(day=schedule.date_range[0], nb_days=schedule.date_range_in_days, \n",
-    "                           telescope=schedule.telescope)\n",
+    "                           telescope=schedule.telescope, defocus_entries=_defocus_entries, force_autofocus=_force_autofocus)\n",
     "    display(Javascript('Jupyter.notebook.execute_cells([11])'))\n",
     "\n",
     "if tab_nest.selected_index == 1:\n",
     "    schedule.telescope = telescope_widget.value\n",
     "    if schedule.observatory.name == 'SNO':\n",
     "        schedule.telescope = 'Artemis'\n",
-    "        SPOCKST.make_plans(day=schedule.day_of_night, nb_days=1, \n",
-    "                           telescope=schedule.telescope)\n",
-    "        \n",
+    "        SPOCKST.make_plans(day=schedule.day_of_night, nb_days=1,\n",
+    "                           telescope=schedule.telescope, defocus_entries=_defocus_entries, force_autofocus=_force_autofocus)\n",
     "    if schedule.observatory.name == 'Saint-Ex':\n",
     "        schedule.telescope = 'Saint-Ex'\n",
     "        SPOCKST.make_plans(day=schedule.day_of_night, nb_days=1, \n",
-    "                           telescope=schedule.telescope)\n",
-    "        \n",
+    "                           telescope=schedule.telescope, defocus_entries=_defocus_entries, force_autofocus=_force_autofocus)\n",
     "    if schedule.observatory.name == 'SSO':\n",
     "        SPOCKST.make_plans(day=schedule.day_of_night, nb_days=1, \n",
-    "                           telescope=schedule.telescope)\n",
+    "                           telescope=schedule.telescope, defocus_entries=_defocus_entries, force_autofocus=_force_autofocus)\n",
     "    display(Javascript('Jupyter.notebook.execute_cells([11])'))\n",
     "        \n",
     "if tab_nest.selected_index == 3:\n",
@@ -1094,38 +1112,61 @@
     "    if schedule.observatory.name == 'SNO':\n",
     "        schedule.telescope = 'Artemis'\n",
     "        SPOCKLT.make_plans(day=schedule.date_range[0], nb_days=schedule.date_range_in_days, \n",
-    "                           telescope=schedule.telescope)\n",
-    "        \n",
+    "                           telescope=schedule.telescope, defocus_entries=_defocus_entries, force_autofocus=_force_autofocus)\n",
     "    if schedule.observatory.name == 'Saint-Ex':\n",
     "        schedule.telescope = 'Saint-Ex'\n",
     "        SPOCKLT.make_plans(day=schedule.date_range[0], nb_days=schedule.date_range_in_days, \n",
-    "                           telescope=schedule.telescope)\n",
-    "\n",
+    "                           telescope=schedule.telescope, defocus_entries=_defocus_entries, force_autofocus=_force_autofocus)\n",
     "    if schedule.observatory.name == 'SSO':\n",
     "        SPOCKLT.make_plans(day=schedule.date_range[0], nb_days=schedule.date_range_in_days, \n",
-    "                           telescope=schedule.telescope)\n",
-    "        \n",
+    "                           telescope=schedule.telescope, defocus_entries=_defocus_entries, force_autofocus=_force_autofocus)\n",
     "    if schedule.observatory.name == 'TS_La_Silla':\n",
     "        schedule.telescope = 'TS_La_Silla'\n",
     "        SPOCKLT.make_plans(day=schedule.date_range[0], nb_days=schedule.date_range_in_days, \n",
-    "                           telescope=schedule.telescope)\n",
-    "        \n",
+    "                           telescope=schedule.telescope, defocus_entries=_defocus_entries, force_autofocus=_force_autofocus)\n",
     "    if schedule.observatory.name == 'TN_Oukaimeden':\n",
     "        schedule.telescope = 'TN_Oukaimeden'\n",
     "        SPOCKLT.make_plans(day=schedule.date_range[0], nb_days=schedule.date_range_in_days, \n",
-    "                           telescope=schedule.telescope)\n",
-    "    display(Javascript('Jupyter.notebook.execute_cells([11])'))"
+    "                           telescope=schedule.telescope, defocus_entries=_defocus_entries, force_autofocus=_force_autofocus)\n",
+    "    display(Javascript('Jupyter.notebook.execute_cells([11])'))\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {
     "jupyter": {
      "source_hidden": true
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5aecf2fa144f4a51b734bcde9df3c259",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Button(description='Upload ACP plans/night-blocks', icon='check', layout=Layout(height='40px', width='30%'), s…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "Jupyter.notebook.execute_cells([12])"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# CELL 11 -- BUTTON -- Upload plans\n",
     "uploadplans_widget = widgets.Button(\n",
@@ -1149,13 +1190,140 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {
     "jupyter": {
      "source_hidden": true
-    }
+    },
+    "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:paramiko.transport:Connected (version 2.0, client OpenSSH_7.4)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mINFO: \u001b[30m Connecting to Cambridge archive (non-critical)...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:paramiko.transport:Authentication (password) successful!\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mINFO: \u001b[30m Connected to Cambridge SSH!\n",
+      "\u001b[32mINFO: \u001b[30m Opening Cambridge SFTP channel (10s timeout)...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:paramiko.transport.sftp:[chan 0] Opened sftp connection (server version 3)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mINFO: \u001b[30m SFTP Cambridge ready\n",
+      "\u001b[32mINFO: \u001b[30m Connecting to SSO hub (172.16.4.169)...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:paramiko.transport:Connected (version 2.0, client OpenSSH_7.8)\n",
+      "INFO:paramiko.transport:Authentication (password) successful!\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mINFO: \u001b[30m Connected to SSO hub!\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:paramiko.transport.sftp:[chan 0] Opened sftp connection (server version 3)\n",
+      "INFO:paramiko.transport:Connected (version 2.0, client OpenSSH_7.9)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mINFO: \u001b[30m SFTP SSO hub ready\n",
+      "\u001b[32mINFO: \u001b[30m Connecting to SNO hub (10.16.83.11)...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:paramiko.transport:Authentication (password) successful!\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mINFO: \u001b[30m Connected to SNO hub!\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:paramiko.transport.sftp:[chan 0] Opened sftp connection (server version 3)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mINFO: \u001b[30m SFTP SNO hub ready\n",
+      "\u001b[32mINFO: \u001b[30m All servers connected!\n",
+      "\u001b[32mINFO: \u001b[30m Uploading to Cambridge for Ganymede...\n",
+      "\u001b[32mINFO: \u001b[30m All files uploaded to Cambridge for Ganymede\n",
+      "\u001b[32mINFO: \u001b[30m Uploading to HUB servers for Ganymede...\n",
+      "\u001b[31mERROR: \u001b[30m SSO hub upload failed: Failure\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:paramiko.transport.sftp:[chan 0] sftp session closed.\n",
+      "INFO:paramiko.transport.sftp:[chan 0] sftp session closed.\n",
+      "INFO:paramiko.transport.sftp:[chan 0] sftp session closed.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m----->\u001b[30m 2026-08-09 Astra plans uploaded to SSO hub for Ganymede\n",
+      "\u001b[32mINFO: \u001b[30m Closing connections...\n"
+     ]
+    }
+   ],
    "source": [
     "# CELL 12 -- Upload plans\n",
     "start_date = Time(datetime.datetime.strptime(str(start_date_widget.value), '%Y-%m-%d')+datetime.timedelta(hours=15)).iso\n",
@@ -1225,41 +1393,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "jupyter": {
      "source_hidden": true
     },
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "da8a52f6d8814d3bb0d0ab232897e72b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Button(description='Save, make, upload', icon='check', layout=Layout(height='40px', width='20%'), style=Button…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/javascript": [
-       "Jupyter.notebook.execute_cells([14])"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# CELL 13 -- BUTTON -- Save plans, Make plans, Upload plans\n",
     "smu_plans_widget = widgets.Button(\n",
@@ -1281,73 +1422,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "jupyter": {
      "source_hidden": true
-    }
+    },
+    "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32mINFO:  \u001b[30m\"/Users/ed268546/Documents/Codes/SPOCK_v2/night_blocks_propositions/night_blocks_Saint-Ex_2026-04-25.txt\" has been over-written to \"/Users/ed268546/Documents/Codes/SPOCK_v2/DATABASE/Saint-Ex/Archive_night_blocks/\"\n",
-      "\n",
-      "\n",
-      "\u001b[32mINFO: \u001b[30mTarget Sp1438+6408 has been scheduled on the 2026-04-25 on Saint-Ex\n",
-      "\u001b[32mINFO: \u001b[30mTarget TOI-7309 has been scheduled on the 2026-04-25 on Saint-Ex\n",
-      "\u001b[32mINFO: \u001b[30mTarget Sp1438+6408_2 has been scheduled on the 2026-04-25 on Saint-Ex\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:paramiko.transport:Connected (version 2.0, client OpenSSH_7.4)\n",
-      "INFO:paramiko.transport:Authentication (publickey) failed.\n",
-      "INFO:paramiko.transport:Authentication (publickey) failed.\n",
-      "INFO:paramiko.transport:Authentication (password) successful!\n",
-      "INFO:paramiko.transport:Connected (version 2.0, client OpenSSH_7.8)\n",
-      "INFO:paramiko.transport:Authentication (publickey) failed.\n",
-      "INFO:paramiko.transport:Authentication (publickey) failed.\n",
-      "INFO:paramiko.transport:Authentication (password) successful!\n",
-      "INFO:paramiko.transport:Connected (version 2.0, client OpenSSH_7.9)\n",
-      "INFO:paramiko.transport:Authentication (publickey) failed.\n",
-      "INFO:paramiko.transport:Authentication (publickey) failed.\n",
-      "INFO:paramiko.transport:Authentication (password) successful!\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Connected to the servers!\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:paramiko.transport.sftp:[chan 0] Opened sftp connection (server version 3)\n",
-      "INFO:paramiko.transport.sftp:[chan 0] Opened sftp connection (server version 3)\n",
-      "INFO:paramiko.transport.sftp:[chan 0] Opened sftp connection (server version 3)\n",
-      "INFO:paramiko.transport.sftp:[chan 0] sftp session closed.\n",
-      "INFO:paramiko.transport.sftp:[chan 0] sftp session closed.\n",
-      "INFO:paramiko.transport.sftp:[chan 0] sftp session closed.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "-----> 2026-04-25 Plans uploaded on the Cambridge server for Saint-Ex\n",
-      "-----> 2026-04-25 Night plans uploaded on the Cambridge server for Saint-Ex\n",
-      "-----> 2026-04-25 Zip Plans_by_dates folder uploaded on the Cambridge server for Saint-Ex\n",
-      "-----> 2026-04-25 Astra folder updated on the Cambridge server for Saint-Ex\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# CELL 14 -- Save Plans, Make plans, and Upload plans\n",
     "if tab_nest.selected_index == 0:\n",
@@ -1570,13 +1652,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {
     "jupyter": {
      "source_hidden": true
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "233504ccf47a471f9b428e11fcfc9550",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(Dropdown(description='telescope', options=('Saint-Ex', 'Io', 'Europa', 'Ganymede', 'Call…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Cell 18 -- Read night plans\n",
     "@interact\n",
@@ -1781,7 +1878,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,

--- a/eScheduler/spe_schedule.py
+++ b/eScheduler/spe_schedule.py
@@ -1104,12 +1104,13 @@ class SPECULOOSScheduler(Scheduler):
             sum_scores = np.zeros(len(_strided_scores))
             sum_scores[good] = np.sum(_strided_scores[good], axis=1)
 
-
+            _failure_reason = 'too_short'
 
             if np.all(constraint_scores == 0) :
                 # No further calculation if no times meet the constraints
                 # print(b,'pb constraints')
                 _is_scheduled = False
+                _failure_reason = 'constraints'
             else:
                 # schedulable in principle, provided the transition
                 # does not prevent us from fitting it in.
@@ -1162,8 +1163,28 @@ class SPECULOOSScheduler(Scheduler):
 
             if not _is_scheduled:
                 unscheduled_blocks.append(b)
-                sys.exit(Fore.RED + 'ERROR: ' + Fore.BLACK
-                     + "Unable to schedule this block with SPECULOOS Scheduler, this happens when the block is too short (<10min)")
+                if _failure_reason == 'constraints':
+                    # Diagnose which constraint(s) failed
+                    failed_constraints = []
+                    seen_constraint_types = set()
+                    all_constraints = list(b.constraints or []) + list(self.constraints or [])
+                    for constraint in all_constraints:
+                        ctype = type(constraint).__name__
+                        if ctype in seen_constraint_types:
+                            continue
+                        seen_constraint_types.add(ctype)
+                        constraint_score = constraint(self.observer, b.target, times=times)
+                        if np.all(constraint_score == 0):
+                            failed_constraints.append(ctype)
+                    if failed_constraints:
+                        print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK
+                             + f' Target "{b.target.name}" not observable. Failed constraint(s): {", ".join(failed_constraints)}.')
+                    else:
+                        print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK
+                             + f' Target "{b.target.name}" is not observable with the given constraints during this night.')
+                else:
+                    print(Fore.YELLOW + 'WARNING: ' + Fore.BLACK
+                         + f' Unable to schedule block for "{b.target.name}" with SPECULOOS Scheduler (block too short or no valid slot).')
 
         empty_space=np.where(~self._get_filled_indices(times))
         if len(empty_space)*time_resolution.value>20:


### PR DESCRIPTION
Add diagnostic handling to SPECULOOSScheduler: introduce a _failure_reason flag, avoid sys.exit on un-schedulable blocks, and print warnings that list which constraint types failed (or a fallback message if the block is too short). This makes scheduling failures non-fatal and provides clearer reasons for unobservable targets (Moon distance, block too short, not observable, etc).

I found this improvement scheduling HD98800, and I was trying to understand why the target was not observable when it has full night visibility (it was moon restriction at the end).